### PR TITLE
feat: add cortex.yaml for plugin

### DIFF
--- a/plugins/example/cortex.yaml
+++ b/plugins/example/cortex.yaml
@@ -10,3 +10,5 @@ info:
   x-cortex-owners:
     - type: EMAIL
       email: david.barnes@cortex.io
+    - type: EMAIL
+      email: cristina.buenahora@cortex.io


### PR DESCRIPTION
## Background

Trying to figure out how to set up Scaffolder to be apply PRs agains the `/plugins` subdirectory.

## This PR

Marks the example plugin as a Cortex entity via a `cortex.yml` file.

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
