### PR TITLE
chore: add simple plugin list to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # cortex-plugins
 
-This is a monorepo housing Cortex-maintained plugins for Cortex. All available plugins live inside of the `plugins` directory, plus an example [Scaffolded](https://www.cortex.io/products/scaffolder) plugin. Each plugin is a separate package that can be built and deployed independently.
+This is a monorepo housing Cortex-maintained plugins for Cortex. All available plugins live inside of [the `plugins` directory](./plugins/), plus an example [Scaffolded](https://www.cortex.io/products/scaffolder) plugin. Each plugin is a separate package that can be built and deployed independently.
+
+## Available plugins
+
+### GitHub Actions
+
+The GitHub Actions plugin allows you to manage GitHub Actions and Workflows from Cortex. This plugin is useful for automating workflows that are triggered by Cortex events.
+
+See the [GitHub Actions plugin README](./plugins/github-actions/README.md) for more information.
+
+### GitHub Releases
+
+The GitHub Releases plugin provides a view of all Releases for a GitHub repository from Cortex.
+
+See the [GitHub Releases plugin README](./plugins/github-releases/README.md) for more information.
+
+### GitHub Issues
+
+The GitHub Issues plugin provides a view of all Issues for a GitHub repository from Cortex.
+
+See the [GitHub Issues plugin README](./plugins/github-issues/README.md) for more information.
 
 ## Using a plugin
 


### PR DESCRIPTION
## Background

To help users find plugins and also allow linking to plugins outside of this repo, we want to enhance the readme with a simple list of plugins available in this repository.

## This PR

* Updates README.md with a list of the currently available plugins

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
