### PR TITLE
feat: update html templates to include iframe-resizer

### DIFF
--- a/plugins/example/src/index.html
+++ b/plugins/example/src/index.html
@@ -1,3 +1,10 @@
 <html>
+  <head>
+    <script
+      defer
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child"
+    ></script>
+  </head>
   <div id="cortex-plugin-root"></div>
 </html>

--- a/plugins/github-actions/src/index.html
+++ b/plugins/github-actions/src/index.html
@@ -1,3 +1,10 @@
 <html>
+  <head>
+    <script
+      defer
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child"
+    ></script>
+  </head>
   <div id="cortex-plugin-root"></div>
 </html>

--- a/plugins/github-issues/src/index.html
+++ b/plugins/github-issues/src/index.html
@@ -1,3 +1,10 @@
 <html>
+  <head>
+    <script
+      defer
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child"
+    ></script>
+  </head>
   <div id="cortex-plugin-root"></div>
 </html>

--- a/plugins/github-releases/src/index.html
+++ b/plugins/github-releases/src/index.html
@@ -1,3 +1,10 @@
 <html>
+  <head>
+    <script
+      defer
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child"
+    ></script>
+  </head>
   <div id="cortex-plugin-root"></div>
 </html>

--- a/plugins/gitlab-issues/src/index.html
+++ b/plugins/gitlab-issues/src/index.html
@@ -1,3 +1,10 @@
 <html>
+  <head>
+    <script
+      defer
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child"
+    ></script>
+  </head>
   <div id="cortex-plugin-root"></div>
 </html>


### PR DESCRIPTION
## Background

To accommodate iframe (re)sizing, we rely on [iframe-resizer](https://iframe-resizer.com/). This requires that both the parent and child iframe use a package.

The plugins in this repo were created before we added the child package to the plugin template and so are missing the child.

Jira: https://cortex1.atlassian.net/browse/CET-9465

## This PR

Pulls in https://github.com/cortexapps/cookiecutter-cortex-plugin/pull/18

**Note**: There is a temporary issue with v4 vs v5 of iframe-resizer. This PR applies v5, which _will still work_ even if the parent is on v4 (albeit it may not be perfect). This is still a net improvement over not having any of this functionality (we force a refresh after a few seconds if we don't detect iframe-resizer in the child).

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
