### PR TITLE
chore: remove FoodProduct from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @cristinabuenahora @FoodProduct
+* @cristinabuenahora


### PR DESCRIPTION
## Background

FoodProduct is leaving Cortex and will no longer be maintaining this library

## This PR

Removes FoodProduct from codeowners

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
