### PR TITLE
remove hardcoded URL, add instructions, fix tests

### DIFF
--- a/plugins/confluence-plugin/README.md
+++ b/plugins/confluence-plugin/README.md
@@ -6,25 +6,42 @@ This plugin makes it possible to view Confluence assets alongside related entiti
 
 This is a [Cortex](https://www.cortex.io/) plugin. To see how to run the plugin inside of Cortex, see [our docs](https://docs.cortex.io/docs/plugins).
 
-### Prerequisites
+## Setup
 
-The URL of your Confluence instance should be configured in `src/components/PageContent.tsx`. To do so, change the following line to match the URL of your server:
+### Find your Confluence instance URL
+
+Your Confluence instance URL should look like `https://something.atlassian.net`. We will use this URL in the plugin's proxy and in the plugin's configuration entity.
+
+### Set your Confluence credentials
+
+If you are using username and password authentication, type them in to a text editor with a colon (`:`) between them. If you are using SSO, use an API token in place of the password. To create an API token in Confluence by clicking on Security > Create and manage API tokens > Create API token. Once you have your text in your text editor like `myusername@example.com:MySecretPassWordOrToken`, you need to base64 encode it. You can do this using an online tool like [this](https://www.base64encode.org). You will add the base64 encoded value to Cortex as a secret. Copy the base64 encoded value. In Cortex, click on Settings > Secrets > Add secret. In Secret name, type `confluence_secret`, paste the base64 encoded secret into Secret value, and click on Create secret.
+
+### Set up a Plugin Proxy
+
+After you've saved the secret, we will set up a proxy to use that secret to communicate with Confluence. In Cortex, click on Plugins > Proxies > Create Proxy. In Name, type `Confluence Proxy`. Click on Add URL, and put in your Confluence Instance URL, like `https://something.atlassian.net`. Click Save. Next, click on "Add header to https://something.atlassian.net". In the dialog box that appears, type `Authorization` in the Name field, and in the Value field, type `Basic {{{secrets.confluence_secret}}}`. Make sure you include the three curly braces, and make sure the secret name matches the secret you created above, with `secrets.` in front of it. Click Save, then click on the Create Proxy button.
+
+### Associate the plugin with the plugin proxy
+
+Create or edit your Confluence Plugin. In the dropdown under the Associated Proxy heading, choose the Confluence proxy you created above. Next, click Save plugin at the bottom of the page.
+
+### Create a plugin configuration entity
+
+- Consider creating a new entity type, so that any existing scorecards are not affected by ths configuration entity. In this example, we have created a new entity type called `plugin-configuration`
+- Create a new entity with the tag `confluence-plugin-config`
+- Set `x-cortex-definition.confluence-url` to the value of your Confluence Instance URL. For example, if my Confluence Instance URL was `https://martindstone.service-now.com`, my `confluence-plugin-config` entity would look like this:
 
 ```
-const baseConfluenceUrl = "https://confluence-server.atlassian.net";
+openapi: 3.0.1
+info:
+  title: Confluence Plugin Config
+  description: ""
+  x-cortex-tag: confluence-plugin-config
+  x-cortex-type: plugin-configuration
+  x-cortex-definition:
+    confluence-url: https://martindstone.service-now.com
 ```
 
-Developing and building this plugin requires either [yarn](https://classic.yarnpkg.com/lang/en/docs/install/) or [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
-
-## Getting started
-
-1. Modify the `src/components/PageContent.tsx` file as described above
-2. Run `yarn` to download all dependencies
-3. Run `yarn build` to compile the plugin code into `./dist/ui.html`
-4. Upload `ui.html` into Cortex on a create or edit plugin page
-5. Add or update the code and repeat steps 2-3 as necessary
-
-## Adding Confluence Content
+### Adding Confluence content to entities
 
 Entities can be associated with Confluence Page IDs by adding a PageID tag to the `x-cortex-confluence` object. In the Entity yaml for the entity to the Page ID that you'd like to view inside of Cortex, such as:
 
@@ -34,3 +51,13 @@ x-cortex-confluence:
 ```
 
 You can do this for Custom Entities, as well as any Service entity.
+
+### Done!
+
+Now when you load the Confluence plugin on an entity that has a Confluence page ID in `x-cortex-confluence.pageID`, you should see the content of that page in Cortex!
+
+## Building the plugin
+
+1. Run `yarn` to download all dependencies
+2. Run `yarn build` to compile the plugin code into `./dist/ui.html`
+3. Upload `ui.html` into Cortex on a create or edit plugin page

--- a/plugins/confluence-plugin/README.md
+++ b/plugins/confluence-plugin/README.md
@@ -14,7 +14,7 @@ Your Confluence instance URL should look like `https://something.atlassian.net`.
 
 ### Set your Confluence credentials
 
-If you are using username and password authentication, type them in to a text editor with a colon (`:`) between them. If you are using SSO, use an API token in place of the password. To create an API token in Confluence by clicking on Security > Create and manage API tokens > Create API token. Once you have your text in your text editor like `myusername@example.com:MySecretPassWordOrToken`, you need to base64 encode it. You can do this using an online tool like [this](https://www.base64encode.org). You will add the base64 encoded value to Cortex as a secret. Copy the base64 encoded value. In Cortex, click on Settings > Secrets > Add secret. In Secret name, type `confluence_secret`, paste the base64 encoded secret into Secret value, and click on Create secret.
+If you are using username and password authentication, type them in to a text editor with a colon (`:`) between them. If you are using SSO, use an API token in place of the password. To create an API token in Confluence, follow the [instructions provided by Atlassian](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/). Once you have your text in your text editor like `myusername@example.com:MySecretPassWordOrToken`, you need to base64 encode it. You can do this using an online tool like [this](https://www.base64encode.org). You will add the base64 encoded value to Cortex as a secret. Copy the base64 encoded value. In Cortex, click on Settings > Secrets > Add secret. In Secret name, type `confluence_secret`, paste the base64 encoded secret into Secret value, and click on Create secret.
 
 ### Set up a Plugin Proxy
 

--- a/plugins/confluence-plugin/src/components/App.test.tsx
+++ b/plugins/confluence-plugin/src/components/App.test.tsx
@@ -1,53 +1,41 @@
-import { render, screen, waitFor } from "@testing-library/react";
+// import { render, screen, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
+import fetchMock from "jest-fetch-mock";
 import App from "./App";
 
-const mockPageContent = {
-  id: "131073",
-  type: "page",
-  status: "current",
-  title: "AppDirect Runbook",
-  macroRenderedOutput: {},
-  body: {
-    view: {
-      value:
-        '<p><style>[data-colorid=kggi8475gd]{color:#bf2600} html[data-color-mode=dark] [data-colorid=kggi8475gd]{color:#ff6640}</style><strong>This document describes what we do when it breaks!</strong></p><p><br />Step 1 - <span data-colorid="kggi8475gd">EVERYBODY</span> PANIC!!!!!!!</p><p>Step2 - Run to the hills</p><p>Step3 - Run for your lives</p><p /><h2 id="AppDirectRunbook-ArchitecturalDigram">Architectural Digram</h2><span class="confluence-embedded-file-wrapper image-center-wrapper confluence-embedded-manual-size"><img class="confluence-embedded-image image-center" alt="cloud_infrastructure (3).png" width="760" loading="lazy" src="https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=760&amp;height=888" data-image-src="https://cortex-se-test.atlassian.net/wiki/download/attachments/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2" data-height="1632" data-width="1396" data-unresolved-comment-count="0" data-linked-resource-id="2523157" data-linked-resource-version="1" data-linked-resource-type="attachment" data-linked-resource-default-alias="cloud_infrastructure (3).png" data-base-url="https://cortex-se-test.atlassian.net/wiki" data-linked-resource-content-type="image/png" data-linked-resource-container-id="131073" data-linked-resource-container-version="4" data-media-id="d04b592d-798d-486e-80af-6af581929d0b" data-media-type="file" srcset="https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=1095&amp;height=1280 2x, https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=760&amp;height=888 1x" /></span><p />',
-      representation: "view",
-      _expandable: {
-        webresource: "",
-        embeddedContent: "",
-        mediaToken: "",
-        content: "/rest/api/content/131073",
-      },
-    },
-    _expandable: {
-      editor: "",
-      atlas_doc_format: "",
-      export_view: "",
-      styled_view: "",
-      dynamic: "",
-      storage: "",
-      editor2: "",
-      anonymous_export_view: "",
-    },
-  },
-};
-
-const serviceYaml = {
-  info: {
-    "x-cortex-confluence": { pageID: 131073 },
-  },
-};
+import { successMockBodies } from "../mocks/mockBodies";
 
 describe("App", () => {
-  fetchMock.mockResponses(
-    [JSON.stringify(serviceYaml), { status: 200 }],
-    [JSON.stringify(mockPageContent), { status: 200 }]
-  );
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
 
   it("verifies that the plugin works", async () => {
-    render(<App />);
+    fetchMock.mockResponse(async (req) => {
+      const url = req.url.split("?")[0];
+      if (!successMockBodies[url]) {
+        return { status: 404 };
+      }
+      return {
+        status: 200,
+        body: JSON.stringify(successMockBodies[url]),
+      };
+    });
+
+    const { getByText } = render(<App />);
     await waitFor(() => {
-      expect(screen.queryByText("AppDirect Runbook")).toBeInTheDocument();
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.cortex.dev/catalog/confluence-plugin-config/openapi"
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.cortex.dev/catalog/inventory-planner/openapi"
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /https:\/\/unit-testing-confluence-instance.atlassian.net.*131073.*/
+        )
+      );
+      expect(getByText("AppDirect Runbook")).toBeInTheDocument();
     });
   });
 });

--- a/plugins/confluence-plugin/src/components/App.test.tsx
+++ b/plugins/confluence-plugin/src/components/App.test.tsx
@@ -1,4 +1,3 @@
-// import { render, screen, waitFor } from "@testing-library/react";
 import { render, waitFor } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import App from "./App";

--- a/plugins/confluence-plugin/src/components/Instructions.tsx
+++ b/plugins/confluence-plugin/src/components/Instructions.tsx
@@ -1,0 +1,28 @@
+import type React from "react";
+
+import { Text, Box } from "@cortexapps/plugin-core/components";
+
+const Instructions: React.FC = () => (
+  <Box backgroundColor="light" margin={2} padding={4} borderRadius={2}>
+    <Text>
+      This plugin makes it possible to view Confluence assets associated with an
+      entity.
+    </Text>
+    <Text>
+      To get started, please add an entity to Cortex like the following:
+    </Text>
+    <Box marginTop={4} padding={4} backgroundColor="white" borderRadius={2}>
+      <pre>
+        {`openapi: 3.0.1
+info:
+  title: Confluence Plugin Config
+  x-cortex-tag: confluence-plugin-config
+  x-cortex-type: pluginconfiguration
+  x-cortex-definition:
+    confluence-url: https://YOUR_INSTANCE.atlassian.net`}
+      </pre>
+    </Box>
+  </Box>
+);
+
+export default Instructions;

--- a/plugins/confluence-plugin/src/components/PageContent.test.tsx
+++ b/plugins/confluence-plugin/src/components/PageContent.test.tsx
@@ -1,42 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import PageContent from "./PageContent";
 
-const mockPageContent = {
-  id: "131073",
-  type: "page",
-  status: "current",
-  title: "AppDirect Runbook",
-  macroRenderedOutput: {},
-  body: {
-    view: {
-      value:
-        '<p><style>[data-colorid=kggi8475gd]{color:#bf2600} html[data-color-mode=dark] [data-colorid=kggi8475gd]{color:#ff6640}</style><strong>This document describes what we do when it breaks!</strong></p><p><br />Step 1 - <span data-colorid="kggi8475gd">EVERYBODY</span> PANIC!!!!!!!</p><p>Step2 - Run to the hills</p><p>Step3 - Run for your lives</p><p /><h2 id="AppDirectRunbook-ArchitecturalDigram">Architectural Digram</h2><span class="confluence-embedded-file-wrapper image-center-wrapper confluence-embedded-manual-size"><img class="confluence-embedded-image image-center" alt="cloud_infrastructure (3).png" width="760" loading="lazy" src="https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=760&amp;height=888" data-image-src="https://cortex-se-test.atlassian.net/wiki/download/attachments/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2" data-height="1632" data-width="1396" data-unresolved-comment-count="0" data-linked-resource-id="2523157" data-linked-resource-version="1" data-linked-resource-type="attachment" data-linked-resource-default-alias="cloud_infrastructure (3).png" data-base-url="https://cortex-se-test.atlassian.net/wiki" data-linked-resource-content-type="image/png" data-linked-resource-container-id="131073" data-linked-resource-container-version="4" data-media-id="d04b592d-798d-486e-80af-6af581929d0b" data-media-type="file" srcset="https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=1095&amp;height=1280 2x, https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=760&amp;height=888 1x" /></span><p />',
-      representation: "view",
-      _expandable: {
-        webresource: "",
-        embeddedContent: "",
-        mediaToken: "",
-        content: "/rest/api/content/131073",
-      },
-    },
-    _expandable: {
-      editor: "",
-      atlas_doc_format: "",
-      export_view: "",
-      styled_view: "",
-      dynamic: "",
-      storage: "",
-      editor2: "",
-      anonymous_export_view: "",
-    },
-  },
-};
-
-const serviceYaml = {
-  info: {
-    "x-cortex-confluence": { pageID: 131073 },
-  },
-};
+import { successMockBodies } from "../mocks/mockBodies";
 
 describe("PageContent", () => {
   beforeEach(() => {
@@ -44,10 +9,16 @@ describe("PageContent", () => {
   });
 
   it("shows message when no page is found", async () => {
-    fetchMock.mockResponses(
-      [JSON.stringify(serviceYaml), { status: 200 }],
-      [JSON.stringify({}), { status: 500 }]
-    );
+    fetchMock.mockResponse(async (req) => {
+      const url = req.url.split("?")[0];
+      if (!successMockBodies[url]) {
+        return { status: 404 };
+      }
+      return {
+        status: 200,
+        body: JSON.stringify(successMockBodies[url]),
+      };
+    });
 
     render(<PageContent />);
 
@@ -61,10 +32,16 @@ describe("PageContent", () => {
   });
 
   it("shows a page if page is found", async () => {
-    fetchMock.mockResponses(
-      [JSON.stringify(serviceYaml), { status: 200 }],
-      [JSON.stringify(mockPageContent), { status: 200 }]
-    );
+    fetchMock.mockResponse(async (req) => {
+      const url = req.url.split("?")[0];
+      if (!successMockBodies[url]) {
+        return { status: 404 };
+      }
+      return {
+        status: 200,
+        body: JSON.stringify(successMockBodies[url]),
+      };
+    });
 
     render(<PageContent />);
     await waitFor(() => {
@@ -87,10 +64,16 @@ describe("PageContent", () => {
   });
 
   it("renders content with dangerouslySetInnerHTML", async () => {
-    fetchMock.mockResponses(
-      [JSON.stringify(serviceYaml), { status: 200 }],
-      [JSON.stringify(mockPageContent), { status: 200 }]
-    );
+    fetchMock.mockResponse(async (req) => {
+      const url = req.url.split("?")[0];
+      if (!successMockBodies[url]) {
+        return { status: 404 };
+      }
+      return {
+        status: 200,
+        body: JSON.stringify(successMockBodies[url]),
+      };
+    });
 
     render(<PageContent />);
     await waitFor(() => {

--- a/plugins/confluence-plugin/src/components/PageContent.test.tsx
+++ b/plugins/confluence-plugin/src/components/PageContent.test.tsx
@@ -24,9 +24,7 @@ describe("PageContent", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          "No Confluence details exist on this entity."
-        )
+        screen.getByText("No Confluence details exist on this entity.")
       ).toBeInTheDocument();
     });
   });

--- a/plugins/confluence-plugin/src/components/PageContent.test.tsx
+++ b/plugins/confluence-plugin/src/components/PageContent.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import PageContent from "./PageContent";
 
-import { successMockBodies } from "../mocks/mockBodies";
+import { successMockBodies, noEntityMockBodies } from "../mocks/mockBodies";
 
 describe("PageContent", () => {
   beforeEach(() => {
@@ -11,12 +11,12 @@ describe("PageContent", () => {
   it("shows message when no page is found", async () => {
     fetchMock.mockResponse(async (req) => {
       const url = req.url.split("?")[0];
-      if (!successMockBodies[url]) {
+      if (!noEntityMockBodies[url]) {
         return { status: 404 };
       }
       return {
         status: 200,
-        body: JSON.stringify(successMockBodies[url]),
+        body: JSON.stringify(noEntityMockBodies[url]),
       };
     });
 
@@ -25,7 +25,7 @@ describe("PageContent", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "We could not find any Confluence page associated with this entity"
+          "No Confluence details exist on this entity."
         )
       ).toBeInTheDocument();
     });
@@ -56,8 +56,8 @@ describe("PageContent", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          "We could not find any Confluence page associated with this entity"
+        screen.queryByText(
+          "To get started, please add an entity to Cortex like the following:"
         )
       ).toBeInTheDocument();
     });

--- a/plugins/confluence-plugin/src/components/PageContent.tsx
+++ b/plugins/confluence-plugin/src/components/PageContent.tsx
@@ -37,7 +37,7 @@ const PageContent: React.FC = () => {
         );
         const data = await response.json();
         newConfluenceUrl = data.info["x-cortex-definition"]["confluence-url"];
-      } catch (e) { }
+      } catch (e) {}
       setBaseConfluenceUrl(newConfluenceUrl);
       if (!newConfluenceUrl) {
         setErrorStr("instructions");
@@ -69,9 +69,15 @@ const PageContent: React.FC = () => {
             let newErrorStr = "";
             // if the contentResult contains valid JSON, we can use it to display an error message
             try {
-              if (contentResult.headers.get("content-type")?.includes("application/json")) {
+              if (
+                contentResult.headers
+                  .get("content-type")
+                  ?.includes("application/json")
+              ) {
                 const contentJSON = await contentResult.json();
-                newErrorStr = `Failed to fetch Confluence page with ID ${pageID.pageID}: ${contentJSON.message || JSON.stringify(contentJSON)}`;
+                const msg: string =
+                  contentJSON.message || JSON.stringify(contentJSON);
+                newErrorStr = `Failed to fetch Confluence page with ID ${pageID.pageID}: ${msg}`;
               } else {
                 // just get the text if it's not JSON
                 const contentText = await contentResult.text();
@@ -79,7 +85,8 @@ const PageContent: React.FC = () => {
               }
             } catch (e) {
               // if we can't parse the content, just use the status text
-              newErrorStr = contentResult.statusText || "Failed to fetch Confluence page";
+              newErrorStr =
+                contentResult.statusText || "Failed to fetch Confluence page";
             }
             setErrorStr(newErrorStr);
             return;
@@ -90,7 +97,8 @@ const PageContent: React.FC = () => {
           setErrorStr("");
         } catch (e) {
           // This will still result in a "We could not find any Confluence page" error in the UI, but may as well trap in console as well
-          setErrorStr(`Error retrieving Confluence page: ${e.message || e.toString()}`);
+          const msg: string = e.message || e.toString();
+          setErrorStr(`Error retrieving Confluence page: ${msg}`);
           console.error("Error retrieving Confluence page: ", e);
         }
       }

--- a/plugins/confluence-plugin/src/mocks/mockBodies.ts
+++ b/plugins/confluence-plugin/src/mocks/mockBodies.ts
@@ -1,0 +1,56 @@
+export const successMockBodies = {
+  "https://api.cortex.dev/catalog/confluence-plugin-config/openapi": {
+    info: {
+      "x-cortex-definition": {
+        "confluence-url":
+          "https://unit-testing-confluence-instance.atlassian.net",
+      },
+    },
+  },
+  "https://api.cortex.dev/catalog/inventory-planner/openapi": {
+    info: {
+      title: "Inventory Planner",
+      description: "it is a inventory planner",
+      "x-cortex-tag": "inventory-planner",
+      "x-cortex-type": "service",
+      "x-cortex-confluence": { pageID: 131073 },
+    },
+    openapi: "3.0.1",
+    servers: [
+      {
+        url: "/",
+      },
+    ],
+  },
+  "https://unit-testing-confluence-instance.atlassian.net/wiki/rest/api/content/131073":
+    {
+      id: "131073",
+      type: "page",
+      status: "current",
+      title: "AppDirect Runbook",
+      macroRenderedOutput: {},
+      body: {
+        view: {
+          value:
+            '<p><style>[data-colorid=kggi8475gd]{color:#bf2600} html[data-color-mode=dark] [data-colorid=kggi8475gd]{color:#ff6640}</style><strong>This document describes what we do when it breaks!</strong></p><p><br />Step 1 - <span data-colorid="kggi8475gd">EVERYBODY</span> PANIC!!!!!!!</p><p>Step2 - Run to the hills</p><p>Step3 - Run for your lives</p><p /><h2 id="AppDirectRunbook-ArchitecturalDigram">Architectural Digram</h2><span class="confluence-embedded-file-wrapper image-center-wrapper confluence-embedded-manual-size"><img class="confluence-embedded-image image-center" alt="cloud_infrastructure (3).png" width="760" loading="lazy" src="https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=760&amp;height=888" data-image-src="https://cortex-se-test.atlassian.net/wiki/download/attachments/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2" data-height="1632" data-width="1396" data-unresolved-comment-count="0" data-linked-resource-id="2523157" data-linked-resource-version="1" data-linked-resource-type="attachment" data-linked-resource-default-alias="cloud_infrastructure (3).png" data-base-url="https://cortex-se-test.atlassian.net/wiki" data-linked-resource-content-type="image/png" data-linked-resource-container-id="131073" data-linked-resource-container-version="4" data-media-id="d04b592d-798d-486e-80af-6af581929d0b" data-media-type="file" srcset="https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=1095&amp;height=1280 2x, https://cortex-se-test.atlassian.net/wiki/download/thumbnails/131073/cloud_infrastructure%20(3).png?version=1&amp;modificationDate=1706209753278&amp;cacheVersion=1&amp;api=v2&amp;width=760&amp;height=888 1x" /></span><p />',
+          representation: "view",
+          _expandable: {
+            webresource: "",
+            embeddedContent: "",
+            mediaToken: "",
+            content: "/rest/api/content/131073",
+          },
+        },
+        _expandable: {
+          editor: "",
+          atlas_doc_format: "",
+          export_view: "",
+          styled_view: "",
+          dynamic: "",
+          storage: "",
+          editor2: "",
+          anonymous_export_view: "",
+        },
+      },
+    },
+};

--- a/plugins/confluence-plugin/src/mocks/mockBodies.ts
+++ b/plugins/confluence-plugin/src/mocks/mockBodies.ts
@@ -54,3 +54,21 @@ export const successMockBodies = {
       },
     },
 };
+
+export const noEntityMockBodies = {
+  ...successMockBodies,
+  "https://api.cortex.dev/catalog/inventory-planner/openapi": {
+    info: {
+      title: "Inventory Planner",
+      description: "it is a inventory planner",
+      "x-cortex-tag": "inventory-planner",
+      "x-cortex-type": "service",
+    },
+    openapi: "3.0.1",
+    servers: [
+      {
+        url: "/",
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Background

Confluence plugin had a hardcoded URL, marketplace plugins need to work without being recompiled.

## This PR

Removed the hardcoded URL and added code to get the URL from a plugin config entity; added instructions to create the plugin config entity if it's not found.

## Checklists

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines
