### PR TITLE
fix expand button showing thru overlay

### DIFF
--- a/plugins/info-cards/src/components/InfoCardForm.tsx
+++ b/plugins/info-cards/src/components/InfoCardForm.tsx
@@ -61,7 +61,7 @@ export default function InfoCardForm({
     padding: "2rem",
     width: "100%",
     height: "100%",
-    zIndex: 1,
+    zIndex: 2,
   };
 
   const expandButtonStyle: React.CSSProperties = {


### PR DESCRIPTION
## Background

Expand button was showing through the expanded editor overlay :(

## This PR

Changes the zIndex of the overlay so that the expand button won't show through

## Checklists

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines
